### PR TITLE
fix --

### DIFF
--- a/src/lib/packages.ts
+++ b/src/lib/packages.ts
@@ -178,10 +178,7 @@ export async function execScript({
   }
 
   debug(f`Falling back to run ${scriptName} in ${packageName}`);
-  return exec(
-    args ? `${fallbackScript} -- ${args}` : fallbackScript,
-    packageName,
-  );
+  return exec(args ? `${fallbackScript} ${args}` : fallbackScript, packageName);
 }
 
 export namespace execScript {


### PR DESCRIPTION
by injecting `--` into the fallback script invocation, we were inadvertently excluding additional args from scripts defined in `.clarkrc` rather than a local `package.json`.